### PR TITLE
UserVoice Service Hook for Nutshell

### DIFF
--- a/lib/services/nutshell.rb
+++ b/lib/services/nutshell.rb
@@ -1,0 +1,38 @@
+class Services::Nutshell < Services::Base
+  service_name "Nutshell"
+  events_allowed %w[ new_ticket new_ticket_reply new_ticket_admin_reply new_ticket_note]
+
+  string  :api_key,  lambda { _("API Key") }, lambda { _('API Key for Nutshell account'), lambda { _('See %{link}') % {:link => '<a href="https://app.nutshell.com/setup/api-key/uservoice">https://app.nutshell.com/setup/api-key/uservoice</a>'.html_safe} }
+
+  def perform
+    return false if data['api_key'].blank?
+
+    nut_endpoint = "https://app.nutshell.com/api/v1/public/uservoice/#{data['api_key'].strip}"
+
+    uri = URI.parse(nut_endpoint)
+
+    request = Net::HTTP::Post.new(uri.path)
+    request["Content-Type"] = "application/json"
+    request.body = message
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    response = http.request(request)
+    return response.is_a?(Net::HTTPSuccess)
+    rescue EOFError => e
+      raise Services::HandledException.new("EOFError")
+    rescue Errno::ETIMEDOUT => e
+      raise Services::HandledException.new("Errno::ETIMEDOUT")
+    rescue Errno::EPIPE => e
+      raise Services::HandledException.new("Errno::EPIPE")
+    rescue Errno::ECONNREFUSED => e
+      raise Services::HandledException.new("Errno::ECONNREFUSED")
+    rescue Timeout::Error => e
+      raise Services::HandledException.new("Timeout::Error")
+  end
+
+  def message
+    api_hash.to_json
+  end
+
+end

--- a/lib/services/nutshell.rb
+++ b/lib/services/nutshell.rb
@@ -2,13 +2,12 @@ class Services::Nutshell < Services::Base
   service_name "Nutshell"
   events_allowed %w[ new_ticket new_ticket_reply new_ticket_admin_reply new_ticket_note]
 
-  string  :api_key,  lambda { _("API Key") }, lambda { _('API Key for Nutshell account'), lambda { _('See %{link}') % {:link => '<a href="https://app.nutshell.com/setup/api-key/uservoice">https://app.nutshell.com/setup/api-key/uservoice</a>'.html_safe} }
+  string  :api_key,  lambda { _("API Key") }, lambda { _('See %{link}') % {:link => '<a href="https://app.nutshell.com/setup/api-key/uservoice">https://app.nutshell.com/setup/api-key/uservoice</a>'.html_safe} }
 
   def perform
     return false if data['api_key'].blank?
 
     nut_endpoint = "https://app.nutshell.com/api/v1/public/uservoice/#{data['api_key'].strip}"
-
     uri = URI.parse(nut_endpoint)
 
     request = Net::HTTP::Post.new(uri.path)
@@ -19,20 +18,23 @@ class Services::Nutshell < Services::Base
     http.use_ssl = true
     response = http.request(request)
     return response.is_a?(Net::HTTPSuccess)
-    rescue EOFError => e
-      raise Services::HandledException.new("EOFError")
-    rescue Errno::ETIMEDOUT => e
-      raise Services::HandledException.new("Errno::ETIMEDOUT")
-    rescue Errno::EPIPE => e
-      raise Services::HandledException.new("Errno::EPIPE")
-    rescue Errno::ECONNREFUSED => e
-      raise Services::HandledException.new("Errno::ECONNREFUSED")
-    rescue Timeout::Error => e
-      raise Services::HandledException.new("Timeout::Error")
+  rescue EOFError => e
+    raise Services::HandledException.new("EOFError")
+  rescue Errno::ETIMEDOUT => e
+    raise Services::HandledException.new("Errno::ETIMEDOUT")
+  rescue Errno::EPIPE => e
+    raise Services::HandledException.new("Errno::EPIPE")
+  rescue Errno::ECONNREFUSED => e
+    raise Services::HandledException.new("Errno::ECONNREFUSED")
+  rescue Timeout::Error => e
+    raise Services::HandledException.new("Timeout::Error")
   end
 
   def message
-    api_hash.to_json
+    {
+      'data' => api_hash,
+      'event' => event
+    }.to_json
   end
 
 end

--- a/lib/services/nutshell.rb
+++ b/lib/services/nutshell.rb
@@ -11,8 +11,8 @@ class Services::Nutshell < Services::Base
     uri = URI.parse(nut_endpoint)
 
     request = Net::HTTP::Post.new(uri.path)
-    request["Content-Type"] = "application/json"
-    request.body = message
+    request["Content-Type"] = "application/x-www-form-urlencoded"
+    request.set_form_data message
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
@@ -32,9 +32,9 @@ class Services::Nutshell < Services::Base
 
   def message
     {
-      'data' => api_hash,
+      'data' => api_hash.to_json,
       'event' => event
-    }.to_json
+    }
   end
 
 end

--- a/spec/nutshell_spec.rb
+++ b/spec/nutshell_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Services::Nutshell do
+  describe '#perform' do
+    before { stub_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9') }
+
+    context 'new_ticket' do
+      let(:event) { "new_ticket" }
+      let(:api_xml) { fixture(event) }
+      it 'should post to new ticket' do
+            nutshell = Services::Nutshell.new(event, {'api_key' => '1:a56de74ab335d5a5e7f863b65705493a051082d9'}, api_xml)
+            nutshell.perform
+            a_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9').with(:body => nutshell.api_hash).should have_been_made
+      end
+    end
+
+    context 'new_ticket_reply' do
+      let(:event) { "new_ticket_reply" }
+      let(:api_xml) { fixture(event) }
+      it 'should post to new ticket' do
+            nutshell = Services::Nutshell.new(event, {'api_key' => '1:a56de74ab335d5a5e7f863b65705493a051082d9'}, api_xml)
+            nutshell.perform
+            a_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9').with(:body => nutshell.api_hash).should have_been_made
+      end
+    end
+
+    context 'new_ticket_admin_reply' do
+      let(:event) { "new_ticket_admin_reply" }
+      let(:api_xml) { fixture(event) }
+      it 'should post to new ticket' do
+            nutshell = Services::Nutshell.new(event, {'api_key' => '1:a56de74ab335d5a5e7f863b65705493a051082d9'}, api_xml)
+            nutshell.perform
+            a_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9').with(:body => nutshell.api_hash).should have_been_made
+      end
+    end
+  end
+end


### PR DESCRIPTION
A service hook to get UserVoice activity (tickets, contacts) to Nutshell

To test the hook
- create a new nutshell acount (https://www.nutshell.com/signup/)
- access a uservoice api key from your account (app.nutshell.com/setup/api-key/uservoice)
- set that up with the uservoice service hook and the activity should show up in your main nutshell feed (app.nutshell.com)