### PR TITLE
Add Nutshell service hook

### DIFF
--- a/lib/services/nutshell.rb
+++ b/lib/services/nutshell.rb
@@ -1,0 +1,40 @@
+class Services::Nutshell < Services::Base
+  service_name "Nutshell"
+  events_allowed %w[ new_ticket new_ticket_reply new_ticket_admin_reply new_ticket_note ticket_status_update new_suggestion new_comment new_kudo new_user_story suggestion_status_update suggestion_votes_update ]
+
+  string  :api_key, lambda { _("API Key") }, lambda { _('See %{link}') % {:link => '<a href="https://app.nutshell.com/setup/api-key/uservoice">https://app.nutshell.com/setup/api-key/uservoice</a>'.html_safe} }
+
+  def perform
+    return false if data['api_key'].blank?
+
+    nut_endpoint = "https://app.nutshell.com/api/v1/public/uservoice/#{data['api_key'].strip}"
+    uri = URI.parse(nut_endpoint)
+
+    request = Net::HTTP::Post.new(uri.path)
+    request["Content-Type"] = "application/x-www-form-urlencoded"
+    request.set_form_data message
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    response = http.request(request)
+    return response.is_a?(Net::HTTPSuccess)
+  rescue EOFError => e
+    raise Services::HandledException.new("EOFError")
+  rescue Errno::ETIMEDOUT => e
+    raise Services::HandledException.new("Errno::ETIMEDOUT")
+  rescue Errno::EPIPE => e
+    raise Services::HandledException.new("Errno::EPIPE")
+  rescue Errno::ECONNREFUSED => e
+    raise Services::HandledException.new("Errno::ECONNREFUSED")
+  rescue Timeout::Error => e
+    raise Services::HandledException.new("Timeout::Error")
+  end
+
+  def message
+    {
+      'data' => api_hash.to_json,
+      'event' => event
+    }
+  end
+
+end

--- a/spec/nutshell_spec.rb
+++ b/spec/nutshell_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Services::Nutshell do
+  describe '#perform' do
+    before { stub_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9') }
+
+    context 'new_ticket' do
+      let(:event) { "new_ticket" }
+      let(:api_xml) { fixture(event) }
+      it 'should post to new ticket' do
+            nutshell = Services::Nutshell.new(event, {'api_key' => '1:a56de74ab335d5a5e7f863b65705493a051082d9'}, api_xml)
+            nutshell.perform
+            a_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9').with(:body => nutshell.api_hash).should have_been_made
+      end
+    end
+
+    context 'new_ticket_reply' do
+      let(:event) { "new_ticket_reply" }
+      let(:api_xml) { fixture(event) }
+      it 'should post to new ticket' do
+            nutshell = Services::Nutshell.new(event, {'api_key' => '1:a56de74ab335d5a5e7f863b65705493a051082d9'}, api_xml)
+            nutshell.perform
+            a_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9').with(:body => nutshell.api_hash).should have_been_made
+      end
+    end
+
+    context 'new_ticket_admin_reply' do
+      let(:event) { "new_ticket_admin_reply" }
+      let(:api_xml) { fixture(event) }
+      it 'should post to new ticket' do
+            nutshell = Services::Nutshell.new(event, {'api_key' => '1:a56de74ab335d5a5e7f863b65705493a051082d9'}, api_xml)
+            nutshell.perform
+            a_request(:post, 'https://app.nutshell.com/api/v1/public/uservoice/1:a56de74ab335d5a5e7f863b65705493a051082d9').with(:body => nutshell.api_hash).should have_been_made
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is almost identical to #12, with the exception of additionall `events_allowed` entries. I also added the `ticket_status_update` event after discussing with @wlrs, which isn't currently listed in `base.rb`.

This hook is already live thanks to @wlrs, so no rush on getting it merged. Thanks again, Joey!