### PR TITLE
Slack webhook to only post for specific forum

### DIFF
--- a/lib/services/slack.rb
+++ b/lib/services/slack.rb
@@ -2,9 +2,12 @@ class Services::Slack < Services::Base
   service_name "Slack"
   events_allowed %w[ new_ticket new_ticket_reply new_ticket_admin_reply new_suggestion new_comment new_kudo new_article new_forum suggestion_status_update suggestion_votes_update ]
   string :url_hash, lambda { _("Slack Webhook URL") }, lambda { _('For example: https://hooks.slack.com/services/T025T025/A09A09A09A09/ML7ycML7ycML7ycML7yc<br>See %{link}') % {:link => '<a href="https://slack.com/services/new/incoming-webhook">https://slack.com/services/new/incoming-webhook</a>'.html_safe} }
+  string :forum_id, lambda { _("Forum ID") }, lambda { _('Specify the Forum ID if you want to limit posts from only one forum. Only used for new suggestion, new comment, and suggestion status update.') }
 
   def perform
     return false if data['url_hash'].blank?
+    return false unless data['forum_id'].blank? or forum_id.blank? or data['forum_id'] == forum_id
+    
     uri = URI.parse(data['url_hash'])
 
     request = Net::HTTP::Post.new(uri.path)
@@ -20,6 +23,20 @@ class Services::Slack < Services::Base
     response = http.request(request)
 
     return response.is_a?(Net::HTTPSuccess)
+  end
+  
+  def forum_id
+    data = api_hash
+    case event
+      when 'new_suggestion'
+        "#{data['suggestion']['topic']['forum']['id']}"
+      when 'new_comment'
+        "#{data['comment']['forum_id']}"
+      when 'suggestion_status_update'
+        "#{data['audit_status']['suggestion']['topic']['forum']['id']}"
+      else
+        super
+    end
   end
 
   def message


### PR DESCRIPTION
Expose a Forum ID property to Slack webhook config so that the message can be filtered if it is related to a specific Forum ID.

https://feedback.uservoice.com/forums/1-general-feedback/suggestions/3418536-be-able-to-use-service-hooks-with-a-specific-forum